### PR TITLE
Fix Heroku release error

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,6 +16,7 @@ FROM golang:1.15.2
 
 WORKDIR /app
 
+COPY --from=builder /builder/heroku-release.sh .
 COPY --from=builder /builder/soda .
 COPY --from=builder /builder/line_bot_app .
 COPY --from=builder /builder/database.yml.example database.yml


### PR DESCRIPTION
### Description:
Copy release shell for `Heroku`